### PR TITLE
add support for macOS amd64 and aarch64, exclude Linux and other OSs

### DIFF
--- a/Formula/unison-fsmonitor.rb
+++ b/Formula/unison-fsmonitor.rb
@@ -9,9 +9,9 @@ class UnisonFsmonitor < Formula
     raise "formula for unison already provides unison-fsmonitor!"
   elsif OS.mac?
     if Hardware::CPU.intel?
-      url "https://github.com/autozimu/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-amd64.tar.gz"
+      url "https://github.com/porelli/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-amd64.tar.gz"
     elsif Hardware::CPU.arm?
-      url "https://github.com/autozimu/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-aarch64.tar.gz"
+      url "https://github.com/porelli/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-aarch64.tar.gz"
     else
       raise "Unsupported macOS arch!"
     end

--- a/Formula/unison-fsmonitor.rb
+++ b/Formula/unison-fsmonitor.rb
@@ -3,9 +3,22 @@
 class UnisonFsmonitor < Formula
   desc "unison-fsmonitor for macOS"
   homepage "https://github.com/autozimu/unison-fsmonitor"
-  url "https://github.com/autozimu/unison-fsmonitor/releases/download/v0.3.0/unison-fsmonitor.tar.gz"
-  version "0.3.0"
+  version "0.3.2"
 
+  if OS.linux?
+    raise "formula for unison already provides unison-fsmonitor!"
+  elsif OS.mac?
+    if Hardware::CPU.intel?
+      url "https://github.com/autozimu/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-amd64.tar.gz"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/autozimu/unison-fsmonitor/releases/download/v0.3.2/unison-fsmonitor-macos-aarch64.tar.gz"
+    else
+      raise "Unsupported macOS arch!"
+    end
+  else
+    raise "Unsupported OS!"
+  end
+    
   def install
     bin.install "unison-fsmonitor"
   end


### PR DESCRIPTION
Downloads the right macOS binary and raises an error if the formula is being used on a unsupported OS or arch

Companion of this PR: https://github.com/autozimu/unison-fsmonitor/pull/22